### PR TITLE
fix question mark in expr

### DIFF
--- a/builder/expr.go
+++ b/builder/expr.go
@@ -135,11 +135,16 @@ func (e *Ex) Flatten() *Ex {
 	index := 0
 	expr := Expr("")
 	data := e.Bytes()
+	argsLen := e.ArgsLen()
 
 	for i := range data {
 		c := data[i]
 		switch c {
 		case '?':
+			if argsLen == 0 {
+				expr.WriteByte(c)
+				continue
+			}
 			arg := e.args[index]
 			switch a := arg.(type) {
 			case ValuerExpr:
@@ -180,11 +185,16 @@ func (e *Ex) ReplaceValueHolder(bindVar func(idx int) string) *Ex {
 	index := 0
 	expr := Expr("")
 	data := e.Bytes()
+	argsLen := e.ArgsLen()
 
 	for i := range data {
 		c := data[i]
 		switch c {
 		case '?':
+			if argsLen == 0 {
+				expr.WriteByte(c)
+				continue
+			}
 			expr.WriteString(bindVar(index))
 			expr.AppendArgs(e.args[index])
 			index++


### PR DESCRIPTION
table structure:

> +-------+-----------------------------------------------+
    | Table   | Create Table                                  |
   +-------+-----------------------------------------------+
    | x     | CREATE TABLE `x` (
       `id` int(11) DEFAULT NULL,
       `s` varchar(256) DEFAULT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin |
   +-------+-----------------------------------------------+

test code:

```
package main

import (
	"github.com/go-courier/sqlx"
	"github.com/go-courier/sqlx/builder"
	"github.com/go-courier/sqlx/mysqlconnector"
)

var (
	mysqlConnector = &mysqlconnector.MysqlConnector{
		Host:  "root@tcp(0.0.0.0:3306)",
		Extra: "charset=utf8mb4&parseTime=true&interpolateParams=true&autocommit=true&loc=Local",
	}
)

func main() {
	dbTest := &sqlx.Database{
		Name:   "test",
		Tables: builder.Tables{},
	}
	db := dbTest.OpenDB(mysqlConnector)
	db.ExecExpr(builder.Expr("insert into `test`.`x` values(91,'hello1 ? world')"))
	db.QueryExpr(builder.Expr("select * from `test`.`x` where s='hello1 ? world'"))
}

```