### PR TITLE
fix: 'multiple primary keys' error when migrating with unique key who…

### DIFF
--- a/builder/def_key.go
+++ b/builder/def_key.go
@@ -50,7 +50,7 @@ func (key *Key) T() *Table {
 }
 
 func (key *Key) IsPrimary() bool {
-	return key.IsUnique && (strings.ToLower(key.Name) == "primary" || strings.HasSuffix(strings.ToLower(key.Name), "pkey"))
+	return key.IsUnique && strings.ToLower(key.Name) == "primary"
 }
 
 type Keys struct {


### PR DESCRIPTION
model(confpostgres.Postgres):

> //go:generate  tools gen model2 PoItems --database SomeDbName
// @def primary ID
// @def unique_index U_appkey AppKey
type PoItems struct {
	// ID
	ID uint64 `db:"F_id,autoincrement" json:"-"`
	// AppKey
	AppKey string `db:"F_app_key" json:"appKey"`
	// AppSecret
	AppSecret string `db:"F_app_secret" json:"appSecret"`
}

running migration will get error like: 

> failed exec pq: multiple primary keys for table "t_po_items" are not allowed: CREATE TABLE IF NOT EXISTS t_po_items (  f_id bigserial NOT NULL,  f_app_key varchar(255) NOT NULL,  f_app_secret varchar(255) NOT NULL,  PRIMARY KEY (f_id),  PRIMARY KEY (f_app_key) );



